### PR TITLE
Version 0.1.5: Enable silent AutoSave

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ let g:auto_save_no_updatetime = 1  " do not change the 'updatetime' option
 
 ```
 
+AutoSave will display on the status line on each auto-save by default. 
+
+```
+(AutoSaved at 08:40:55)
+```
+
+You can silence the display with the `g:auto_save_silent` option:
+
+```VimL
+" .vimrc
+let g:auto_save_silent = 1  "do not display the auto-save notification
+
+```
+
 ## License
 
 Distributed under the MIT License (see LICENSE.txt).

--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -1,8 +1,8 @@
 "======================================
 "    Script Name:  vim-auto-save (http://www.vim.org/scripts/script.php?script_id=4521)
 "    Plugin Name:  AutoSave
-"        Version:  0.1.4
-"  Last Modified:  03.04.2014 09:53
+"        Version:  0.1.5
+"  Last Modified:  09.15.2014 07:59
 "======================================
 
 if exists("g:auto_save_loaded")
@@ -26,6 +26,10 @@ if g:auto_save_no_updatetime == 0
   set updatetime=200
 endif
 
+if !exists("g:auto_save_silent")
+  let g:auto_save_silent = 0
+endif
+
 au CursorHold,CursorHoldI,InsertLeave * call AutoSave()
 command! AutoSaveToggle :call AutoSaveToggle()
 
@@ -33,7 +37,7 @@ function! AutoSave()
   if g:auto_save >= 1
     let was_modified = &modified
     silent! wa
-    if was_modified && !&modified
+    if was_modified && !&modified && g:auto_save_silent == 0
       echo "(AutoSaved at " . strftime("%H:%M:%S") . ")"
     endif
   endif


### PR DESCRIPTION
You can silence the AutoSave notification in the status line with the
`g:auto_save_silent` option.
