### PR TITLE
Adds g:auto_save_keep_marks to keep the '[ and '] marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Using `InsertLeave` and `TextChanged` only, for example, will save on every chan
 let g:auto_save_events = ["InsertLeave", "TextChanged"]
 ```
 
+This options default value is 1. It fixes the [selecting your pasted
+text](http://vim.wikia.com/wiki/Selecting_your_pasted_text) mapping. Without
+it, the mapping will select the whole buffer, because a write operation sets
+the `'[` and `']` marks respectively to the start and end of the buffer. If you
+want vims default behavior, set the options value to 0:
+
+```VimL
+let g:auto_save_keep_marks = 0 " Don't keep the '[ and '] marks. It will break
+                               " the selecting your pasted text mapping:
+                               " http://vim.wikia.com/wiki/Selecting_your_pasted_text
+```
+
 ## Contribution
 
 Development is made in [907th/vim-auto-save](https://github.com/907th/vim-auto-save) repo.  

--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -37,6 +37,10 @@ if !exists("g:auto_save_events")
   let g:auto_save_events = [ "CursorHold", "InsertLeave" ]
 endif
 
+if !exists("g:auto_save_keep_marks")
+  let g:auto_save_keep_marks = 1
+endif
+
 augroup auto_save
   autocmd!
   if g:auto_save_in_insert_mode == 1
@@ -53,7 +57,15 @@ command! AutoSaveToggle :call AutoSaveToggle()
 function! AutoSave()
   if g:auto_save >= 1
     let was_modified = &modified
-    silent! wa
+    if g:auto_save_keep_marks >= 1
+      let first_char_pos = getpos("'[")
+      let last_char_pos = getpos("']")
+      silent! wa
+      call setpos("'[", first_char_pos)
+      call setpos("']", last_char_pos)
+    else
+      silent! wa
+    endif
     if was_modified && !&modified
       if exists("g:auto_save_postsave_hook")
         execute "" . g:auto_save_postsave_hook


### PR DESCRIPTION
This is useful for the "selecting your pasted text" mapping found here:
http://vim.wikia.com/wiki/Selecting_your_pasted_text