### PR TITLE
Increase default updatetime to 1000

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ let g:auto_save = 1  " enable AutoSave on Vim startup
 
 ```
 
-AutoSave relies on `CursorHold` event and sets the `updatetime` option to 200 so that modifications are saved almost instantly.  
+AutoSave relies on `CursorHold` event and sets the `updatetime` option to 1000 so that modifications are saved every second.  
 But sometimes changing the `updatetime` option may affect other plugins and break things.  
 You can prevent AutoSave from changing the `updatetime` with `g:auto_save_no_updatetime` option:
 

--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -26,7 +26,7 @@ if !exists("g:auto_save_in_insert_mode")
 endif
 
 if g:auto_save_no_updatetime == 0
-  set updatetime=200
+  set updatetime=1000
 endif
 
 if !exists("g:auto_save_silent")


### PR DESCRIPTION
Closes #21 
Vim version is 7.4 ([see vim --version](https://gist.github.com/ammarnajjar/b69972d04b42e10c4e126127d15f8893))
I tested the problem on a fresh docker container with fresh vim installation with the mentioned minimal `.vimrc` in issue #21  and found that system files completion with `<C-x><C-f>` breaks because the default update time is so small (200ms), if you press the combination quickly enough, you might manage to get the desired behavior.
That's why I suggest to increase the default updatetime to 1000.
Still a workaround for issue #21 would be to set:

```viml
let g:auto_save_no_updatetime = 1
```
in `.vimrc` so the system default `updatetime=4000` is maintained.
@907th please advise.