### PR TITLE
check version > 703 when using CompleteDone event

### DIFF
--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -44,7 +44,10 @@ endif
 augroup auto_save
   autocmd!
   if g:auto_save_in_insert_mode == 1
-    let g:auto_save_events = g:auto_save_events + [ "CursorHoldI", "CompleteDone" ]
+    let g:auto_save_events = g:auto_save_events + [ "CursorHoldI" ]
+    if v:version > 703
+        let g:auto_save_events = g:auto_save_events + [ "CompleteDone" ]
+    endif
   endif
 
   for event in g:auto_save_events


### PR DESCRIPTION
Closes the issue mentioned by @ghost starting from [this comment](https://github.com/907th/vim-auto-save/issues/4#issuecomment-58767288), @ldong, @sfahlberg.

Looks like Vim, the version shipping with:
- OS X: VIM - Vi IMproved 7.3 (2010 Aug 15, compiled Aug 24 2013 18:58:47) 
- Ubuntu 12.04:VIM - Vi IMproved 7.3 (2010 Aug 15, compiled May 4 2012 04:25:35)

does not support the event `CompleteDone`, so as a temporary solution I suggest to check for vim version before adding that event to the event list.

Tested only on ubuntu12.04 ([vim --version](https://gist.github.com/ammarnajjar/d3533271cbfcf8decc2fbf7f6b229b42))