### PR TITLE
improving default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ## Description
 
-AutoSave - automatically save changes to disk without having to use `:w` (or any binding to it) every time a buffer has been modified.
+AutoSave - automatically save changes to disk without having to use `:w` (or any binding to it) every time a buffer has been modified or based on your preferred events.
 
 Inspired by the same feature in RubyMine text editor.
+
+By default AutoSave will save every time something has been changed in normal mode and when the user leaves insert mode. This configuration is a mix between "save as often as possible" and "try to avoid breaking other plugins that depend on filewrite-events". 
 
 ## Installation and Usage
 
@@ -20,22 +22,6 @@ let g:auto_save = 1  " enable AutoSave on Vim startup
 
 ```
 
-AutoSave in the default configuration relies on the `CursorHold` event. The `CursorHold` event relies on the `updatetime` option. To have almost instantaneous autosave behavior set the `updatetime` option to a value like 200 milliseconds.
-
-```VimL
-".vimrc
-set updatetime=200
-```
-
-But be advised that changing the `updatetime` option may affect other plugins and break things.
-
-You can disable AutoSave in insert mode with the `g:auto_save_in_insert_mode` option:
-
-```VimL
-" .vimrc
-let g:auto_save_in_insert_mode = 0  " do not save while in insert mode
-
-```
 
 AutoSave will display on the status line on each auto-save by default.
 
@@ -58,11 +44,22 @@ If you need an autosave hook (such as generating tags post-save) then use `g:aut
 let g:auto_save_postsave_hook = 'TagsGenerate'  " this will run :TagsGenerate after each save
 ```
 
-The events on which AutoSave will perform a save can also be adjusted using the `g:auto_save_events` option.
-Using `InsertLeave` and `TextChanged` only, for example, will save on every change in normal mode.
+The events on which AutoSave will perform a save can be adjusted using the `g:auto_save_events` option.
+Using `InsertLeave` and `TextChanged` only, the default, will save on every change in normal mode and every time you leave insert mode.
 
 ```.VimL
 let g:auto_save_events = ["InsertLeave", "TextChanged"]
+```
+
+Using `CursorHold` will additionally save every amount of milliseconds as defined in the `updatetime` option in normal mode.
+`CursorHoldI` will do the same thing in insert mode. `CompleteDone` will also trigger a save after every completion event. See the autocommands overview for a complete listing (`:h autocommand-events`).
+
+Be advised to be careful with the `updatetime` option since it has shown to cause problems when set too small. 200 seems already to be too small to work with certain other plugins. Use 1000 for a more conservative setting.
+
+```.VimL
+".vimrc
+let updatetime=200
+let g:auto_save_events = [ "CursorHold", "CursorHoldI", "CompleteDone", "InsertLeave" ]
 ```
 
 This options default value is 1. It fixes the [selecting your pasted

--- a/README.md
+++ b/README.md
@@ -20,15 +20,14 @@ let g:auto_save = 1  " enable AutoSave on Vim startup
 
 ```
 
-AutoSave relies on `CursorHold` event and sets the `updatetime` option to 1000 so that modifications are saved every second.  
-But sometimes changing the `updatetime` option may affect other plugins and break things.  
-You can prevent AutoSave from changing the `updatetime` with `g:auto_save_no_updatetime` option:
+AutoSave in the default configuration relies on the `CursorHold` event. The `CursorHold` event relies on the `updatetime` option. To have almost instantaneous autosave behavior set the `updatetime` option to a value like 200 milliseconds.
 
 ```VimL
-" .vimrc
-let g:auto_save_no_updatetime = 1  " do not change the 'updatetime' option
-
+".vimrc
+set updatetime=200
 ```
+
+But be advised that changing the `updatetime` option may affect other plugins and break things.
 
 You can disable AutoSave in insert mode with the `g:auto_save_in_insert_mode` option:
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ let updatetime=200
 let g:auto_save_events = [ "CursorHold", "CursorHoldI", "CompleteDone", "InsertLeave" ]
 ```
 
-This options default value is 1. It fixes the [selecting your pasted
-text](http://vim.wikia.com/wiki/Selecting_your_pasted_text) mapping. Without
-it, the mapping will select the whole buffer, because a write operation sets
+The `g:auto_save_keep_marks` option fixes the [selecting your pasted
+text](http://vim.wikia.com/wiki/Selecting_your_pasted_text) mapping.
+This options default value is `1`.
+Without it, the mapping will select the whole buffer, because a write operation sets
 the `'[` and `']` marks respectively to the start and end of the buffer. If you
 want vims default behavior, set the options value to 0:
 
@@ -73,11 +74,11 @@ let g:auto_save_keep_marks = 0 " Don't keep the '[ and '] marks. It will break
                                " the selecting your pasted text mapping:
                                " http://vim.wikia.com/wiki/Selecting_your_pasted_text
 ```
-By default only the current buffer is written. You can choose that all buffers are written on autosave using the `g:auto_save_write_all_buffers` option.
+By default only the current buffer is written (like `:w`). You can choose that all buffers are written on autosave using the `g:auto_save_write_all_buffers` option (like `:wa`).
 
 ```VimL
 let g:auto_save_write_all_buffers = 1 " Setting this option to 1 will write all
-                                      " will write to all open buffers as if you would use
+                                      " open buffers as if you would use
                                       " :wa on the vim command line.
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ let g:auto_save_keep_marks = 0 " Don't keep the '[ and '] marks. It will break
                                " the selecting your pasted text mapping:
                                " http://vim.wikia.com/wiki/Selecting_your_pasted_text
 ```
+By default only the current buffer is written. You can choose that all buffers are written on autosave using the `g:auto_save_write_all_buffers` option.
+
+```VimL
+let g:auto_save_write_all_buffers = 1 " Setting this option to 1 will write all
+                                      " will write to all open buffers as if you would use
+                                      " :wa on the vim command line.
+```
 
 ## Contribution
 

--- a/doc/vim-auto-save.txt
+++ b/doc/vim-auto-save.txt
@@ -1,0 +1,111 @@
+*vim-auto-save.txt*     AutoSave, automatically save current buffer to file
+*vim-auto-save* *auto-save*
+
+
+==============================================================================
+AutoSave Table of Contents
+                                                               *auto-save-toc*
+
+  vim-auto-save
+    Description                        |auto-save-description|
+    Installation                       |auto-save-installation|
+    Options                            |auto-save-options|
+    Contribution                       |auto-save-contribution|
+    License                            |auto-save-license|
+
+==============================================================================
+Description
+                                                       *auto-save-description*
+
+AutoSave - automatically save changes to disk without having to use `:w`
+(or any binding to it) every time a buffer has been modified.
+
+Inspired by the same feature in RubyMine text editor.
+
+==============================================================================
+Installation
+                                                      *auto-save-installation*
+
+Use [vundle](https://github.com/gmarik/vundle) or download [packaged version]
+(http://www.vim.org/scripts/script.php?script_id=4521) from vim.org.
+
+==============================================================================
+Options
+                                                           *auto-save-options*
+
+AutoSave is disabled by default, run `:AutoSaveToggle` to enable/disable it.
+If you want plugin to be always enabled it can be done with `g:auto_save` option:
+>
+  " .vimrc
+  let g:auto_save = 1  " enable AutoSave on Vim startup
+<
+
+                                                     *auto-save-no-updatetime*
+AutoSave relies on `CursorHold` event and sets the `updatetime` option to 1000 so that modifications are saved every second.
+But sometimes changing the `updatetime` option may affect other plugins and break things.
+You can prevent AutoSave from changing the `updatetime` with `g:auto_save_no_updatetime` option:
+>
+  " .vimrc
+  let g:auto_save_no_updatetime = 1  " do not change the 'updatetime' option
+<
+
+                                                    *auto-save-in-insert-mode*
+You can disable AutoSave in insert mode with the `g:auto_save_in_insert_mode` option:
+>
+  " .vimrc
+  let g:auto_save_in_insert_mode = 0  " do not save while in insert mode
+<
+
+                                                            *auto-save-silent*
+AutoSave will display on the status line on each auto-save by default.
+>
+  (AutoSaved at 08:40:55)
+<
+
+You can silence the display with the `g:auto_save_silent` option:
+>
+  " .vimrc
+  let g:auto_save_silent = 1  " do not display the auto-save notification
+<
+
+                                                     *auto-save-postsave-hook*
+If you need an autosave hook (such as generating tags post-save) then use `g:auto_save_postsave_hook` option:
+>
+  " .vimrc
+<
+
+                                                            *auto-save-events*
+The events on which AutoSave will perform a save can also be adjusted using the `g:auto_save_events` option.
+Using `InsertLeave` and `TextChanged` only, for example, will save on every change in normal mode.
+
+>
+  let g:auto_save_events = ["InsertLeave", "TextChanged"]
+<
+
+                                                        *auto-save-keep-marks*
+This options default value is 1. It fixes the [selecting your pasted
+text](http://vim.wikia.com/wiki/Selecting_your_pasted_text) mapping. Without
+it, the mapping will select the whole buffer, because a write operation sets
+the `'[` and `']` marks respectively to the start and end of the buffer. If you
+want vims default behavior, set the options value to 0:
+>
+  let g:auto_save_keep_marks = 0 " Don't keep the '[ and '] marks. It will break
+                                 " the selecting your pasted text mapping:
+<
+
+==============================================================================
+Contribution
+                                                       *auto-save-contribution*
+
+Development is made in [907th/vim-auto-save](https://github.com/907th/vim-auto-save)
+repo.
+
+Feel free to contribute!
+
+==============================================================================
+License
+                                                           *auto-save-license*
+
+Distributed under the MIT License (see LICENSE.txt).
+
+Copyright (c) 2013-2015 Alexey Chernenkov

--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -17,16 +17,12 @@ if !exists("g:auto_save")
   let g:auto_save = 0
 endif
 
-if !exists("g:auto_save_in_insert_mode")
-  let g:auto_save_in_insert_mode = 1
-endif
-
 if !exists("g:auto_save_silent")
   let g:auto_save_silent = 0
 endif
 
 if !exists("g:auto_save_events")
-  let g:auto_save_events = [ "CursorHold", "InsertLeave" ]
+  let g:auto_save_events = [ "InsertLeave", "TextChanged" ]
 endif
 
 if !exists("g:auto_save_keep_marks")
@@ -39,10 +35,6 @@ endif
 
 augroup auto_save
   autocmd!
-  if g:auto_save_in_insert_mode == 1
-    let g:auto_save_events = g:auto_save_events + [ "CursorHoldI", "CompleteDone" ]
-  endif
-
   for event in g:auto_save_events
     execute "au " . event . " * nested call AutoSave()"
   endfor

--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -41,6 +41,10 @@ if !exists("g:auto_save_keep_marks")
   let g:auto_save_keep_marks = 1
 endif
 
+if !exists("g:auto_save_write_all_buffers")
+  let g:auto_save_write_all_buffers = 0
+endif
+
 augroup auto_save
   autocmd!
   if g:auto_save_in_insert_mode == 1
@@ -60,11 +64,11 @@ function! AutoSave()
     if g:auto_save_keep_marks >= 1
       let first_char_pos = getpos("'[")
       let last_char_pos = getpos("']")
-      silent! wa
+      call DoSave()
       call setpos("'[", first_char_pos)
       call setpos("']", last_char_pos)
     else
-      silent! wa
+      call DoSave()
     endif
     if was_modified && !&modified
       if exists("g:auto_save_postsave_hook")
@@ -74,6 +78,14 @@ function! AutoSave()
         echo "(AutoSaved at " . strftime("%H:%M:%S") . ")"
       endif
     endif
+  endif
+endfunction
+
+function! DoSave()
+  if g:auto_save_write_all_buffers >= 1
+    silent! wa
+  else
+    silent! w
   endif
 endfunction
 

--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -17,16 +17,8 @@ if !exists("g:auto_save")
   let g:auto_save = 0
 endif
 
-if !exists("g:auto_save_no_updatetime")
-  let g:auto_save_no_updatetime = 0
-endif
-
 if !exists("g:auto_save_in_insert_mode")
   let g:auto_save_in_insert_mode = 1
-endif
-
-if g:auto_save_no_updatetime == 0
-  set updatetime=1000
 endif
 
 if !exists("g:auto_save_silent")


### PR DESCRIPTION
As discussed in #14 I think that a better default behavior does not rely on updatetime.

Furthermore I think that it might cause problems if we use `wa` instead of `w`. Assuming the user always uses autosave there would be no change in behavior. If the enables and disables it selectively, he might have a reason for why he is doing it and `wa` is taking away power from the user about deciding if he wants to save everything.

Assuming that the user can use `g:auto_save_events` to establish his desired behavior, we no longer need to supply a `let g:auto_save_in_insert_mode` option.