### PR TITLE
Per buffer autosave

### DIFF
--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -42,13 +42,22 @@ augroup auto_save
   for event in g:auto_save_events
 	  " TODO see http://vim.wikia.com/wiki/Run_a_command_in_multiple_buffers
 	  " bufdo
-    execute "au " . event . " * nested  call AutoSave()"
+	  " or http://vimdoc.sourceforge.net/htmldoc/autocmd.html#autocmd-buflocal
+	  " nested => triggers Write/Read events
+    execute "au " . event . " * nested  call RunAutoSaveOnBuffers()"
   endfor
 augroup END
 
+
 command! AutoSaveToggle :call AutoSaveToggle()
 
-function! AutoSave()
+function! RunAutoSaveOnBuffers()
+	let currBuff=bufnr("%")
+	execute 'bufdo '.AutoSaveCurrentBuffer()
+	execute 'buffer '.currBuff
+endfunction
+
+function! AutoSaveCurrentBuffer()
   if !exists("b:auto_save")
 	let b:auto_save = 0
   endif

--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -13,9 +13,6 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
-if !exists("g:auto_save")
-  let g:auto_save = 0
-endif
 
 if !exists("g:auto_save_silent")
   let g:auto_save_silent = 0
@@ -43,14 +40,19 @@ endif
 augroup auto_save
   autocmd!
   for event in g:auto_save_events
-    execute "au " . event . " * nested call AutoSave()"
+	  " TODO see http://vim.wikia.com/wiki/Run_a_command_in_multiple_buffers
+	  " bufdo
+    execute "au " . event . " * nested  call AutoSave()"
   endfor
 augroup END
 
 command! AutoSaveToggle :call AutoSaveToggle()
 
 function! AutoSave()
-  if g:auto_save >= 1
+  if !exists("b:auto_save")
+	let b:auto_save = 0
+  endif
+  if b:auto_save >= 1
     let was_modified = &modified
 
     " preserve marks that are used to remember start and 
@@ -81,11 +83,14 @@ function! DoSave()
 endfunction
 
 function! AutoSaveToggle()
-  if g:auto_save >= 1
-    let g:auto_save = 0
+  if !exists("b:auto_save")
+	let b:auto_save = 0
+  endif
+  if b:auto_save >= 1
+    let b:auto_save = 0
     echo "AutoSave is OFF"
   else
-    let g:auto_save = 1
+    let b:auto_save = 1
     echo "AutoSave is ON"
   endif
 endfunction


### PR DESCRIPTION
This doesn't seem to work when a buffer with autosave enabled is not focused when the event FocusLost is triggered for instance :/

another approach rather than looping through all buffers with bufdo can be to register a per buffer autocmd.
Relates to https://github.com/907th/vim-auto-save/issues/29
