### PR TITLE
Observe buffer specific auto_save option

### DIFF
--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -52,7 +52,7 @@ augroup END
 command AutoSaveToggle :call AutoSaveToggle()
 
 function AutoSave()
-  if g:auto_save == 0
+  if g:auto_save == 0 && b:auto_save==0
     return
   end
 

--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -52,7 +52,7 @@ augroup END
 command AutoSaveToggle :call AutoSaveToggle()
 
 function AutoSave()
-  if g:auto_save == 0 && b:auto_save==0
+  if g:auto_save == 0 && (!exists("b:auto_save") || b:auto_save==0)
     return
   end
 


### PR DESCRIPTION
Check for a buffer specific `b:auto_save` value next to  `g:auto_save`. This allows easy per filetype autosave using autocommands. For example:

```vim
augroup todo
  autocmd!
  autocmd filetype todo let b:auto_save = 1
augroup END
````