### PR TITLE
Allow to override 'g:auto_save' setting for individual buffers/windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ If you want the plugin to be enabled on startup use the `g:auto_save` option.
 let g:auto_save = 1  " enable AutoSave on Vim startup
 ```
 
+It's also possible to override global `g:auto_save` value individually per buffer or window. For example, if you have auto save enabled globally, you can opt out some files. And vice versa, opt in some files, when you have auto save disabled globally.
+
+```vim
+let g:auto_save = 0
+augroup ft_markdown
+  au!
+  au FileType markdown let b:auto_save = 1
+augroup END
+```
+
 ## Silent
 
 AutoSave will display on the status line on each auto-save by default:

--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -52,7 +52,7 @@ augroup END
 command AutoSaveToggle :call AutoSaveToggle()
 
 function AutoSave()
-  if g:auto_save == 0 && (!exists("b:auto_save") || b:auto_save == 0)
+  if s:GetVar('auto_save', 0) == 0
     return
   end
 
@@ -97,6 +97,23 @@ function s:IsModified()
     return len(buffers) > 0
   else
     return &modified
+  endif
+endfunction
+
+" Resolve variable value by climbing up window-buffer-global hierarchy
+" So, buffer-local or window-local variables override global ones
+" If not found on any level, fallbacks to default value or empty string
+function s:GetVar(...)
+  let varName = a:1
+
+  if exists('w:' . varName)
+    return w:{varName}
+  elseif exists('b:' . varName)
+    return b:{varName}
+  elseif exists('g:' . varName)
+    return g:{varName}
+  else
+    return exists('a:2') ? a:2 : ''
   endif
 endfunction
 


### PR DESCRIPTION
This is to follow up https://github.com/907th/vim-auto-save/pull/46

This PR enables overriding `g:auto_save` for individual buffer/window. And, it supports both cases:
1. Auto save is disabled globally (`g:auto_save = 0`). Enable it per buffer/window (`b:auto_save = 1` or `w:auto_save = 1`)
2. Auto save is enabled globally (`g:auto_save = 1`). Disable it per buffer/window (`b:auto_save = 0` or `w:auto_save = 0`)

Case №2 was not supported by https://github.com/907th/vim-auto-save/pull/46, so I've implemented this change.