### PR TITLE
Use `:wall` instead of `:bufdo update`

### DIFF
--- a/plugin/AutoSave.vim
+++ b/plugin/AutoSave.vim
@@ -124,9 +124,7 @@ endfunction
 
 function DoSave()
   if g:auto_save_write_all_buffers >= 1
-    let current_buf = bufnr('%')
-    silent! bufdo update
-    execute 'buffer' . current_buf
+    silent! wall
   else
     silent! update
   endif


### PR DESCRIPTION
@907th I know that you don't maintain this plug-in anymore, but do you still remember, by any chance, if there's an important reason to use `:bufdo update` instead of simply `:wall`?